### PR TITLE
Update esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/parser": "^7.18.8",
     "debug": "^4.3.2",
-    "esbuild": "^0.14.23",
+    "esbuild": "^0.19.4",
     "glob": "^7.1.6",
     "minimatch": "^3.0.4",
     "node-hook": "^1.0.0"


### PR DESCRIPTION
Update esbuild from 0.14.23 to 0.19.4 (the same as the latest version of `@badeball/cypress-cucumber-preprocessor`) to avoid vulnerabilities in go (the language esbuild is written in) 1.19.

Resolves #5.

---

I ran the following on this PR’s branch to verify the selected esbuild version actually addresses what I’ve described in #5:

```sh
syft . -o syft-json > sbom.json
grype sbom:./sbom.json
```

Result:

```
 ✔ Indexed file system                                                                                                                                                                                          .
 ✔ Cataloged contents                                                                                                                            cdb4ee2aea69cc6a83331bbe96dc2caa9a299d21329efb0336fc02a82e1839a8
   └── ✔ Packages                        [8 packages]  
[0000]  WARN no explicit name and version provided for directory source, deriving artifact ID from the given path (which is not ideal)
 ✔ Vulnerability DB                [updated]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
No vulnerabilities found
```

Compare to the result on the `master` branch:

```
 ✔ Indexed file system                                                                                                                                                                                          .
 ✔ Cataloged contents                                                                                                                            cdb4ee2aea69cc6a83331bbe96dc2caa9a299d21329efb0336fc02a82e1839a8
   └── ✔ Packages                        [8 packages]  
[0000]  WARN no explicit name and version provided for directory source, deriving artifact ID from the given path (which is not ideal)
 ✔ Vulnerability DB                [no update available]  
 ✔ Scanned for vulnerabilities     [70 vulnerability matches]  
   ├── by severity: 10 critical, 44 high, 16 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 70 not-fixed, 0 ignored 
NAME    INSTALLED  FIXED-IN  TYPE       VULNERABILITY   SEVERITY 
stdlib  go1.19               go-module  CVE-2023-29405  Critical  
stdlib  go1.19               go-module  CVE-2023-29404  Critical  
stdlib  go1.19               go-module  CVE-2023-29402  Critical  
stdlib  go1.19               go-module  CVE-2023-24540  Critical  
stdlib  go1.19               go-module  CVE-2023-24538  Critical  
stdlib  go1.19               go-module  CVE-2023-45287  High      
stdlib  go1.19               go-module  CVE-2023-45285  High      
stdlib  go1.19               go-module  CVE-2023-45283  High      
stdlib  go1.19               go-module  CVE-2023-44487  High      
stdlib  go1.19               go-module  CVE-2023-39323  High      
stdlib  go1.19               go-module  CVE-2023-29403  High      
stdlib  go1.19               go-module  CVE-2023-29400  High      
stdlib  go1.19               go-module  CVE-2023-24539  High      
stdlib  go1.19               go-module  CVE-2023-24537  High      
stdlib  go1.19               go-module  CVE-2023-24536  High      
stdlib  go1.19               go-module  CVE-2023-24534  High      
stdlib  go1.19               go-module  CVE-2022-41725  High      
stdlib  go1.19               go-module  CVE-2022-41724  High      
stdlib  go1.19               go-module  CVE-2022-41723  High      
stdlib  go1.19               go-module  CVE-2022-41722  High      
stdlib  go1.19               go-module  CVE-2022-41720  High      
stdlib  go1.19               go-module  CVE-2022-41716  High      
stdlib  go1.19               go-module  CVE-2022-41715  High      
stdlib  go1.19               go-module  CVE-2022-32190  High      
stdlib  go1.19               go-module  CVE-2022-2880   High      
stdlib  go1.19               go-module  CVE-2022-2879   High      
stdlib  go1.19               go-module  CVE-2022-27664  High      
stdlib  go1.19               go-module  CVE-2023-45284  Medium    
stdlib  go1.19               go-module  CVE-2023-39326  Medium    
stdlib  go1.19               go-module  CVE-2023-39319  Medium    
stdlib  go1.19               go-module  CVE-2023-39318  Medium    
stdlib  go1.19               go-module  CVE-2023-29409  Medium    
stdlib  go1.19               go-module  CVE-2023-29406  Medium    
stdlib  go1.19               go-module  CVE-2023-24532  Medium    
stdlib  go1.19               go-module  CVE-2022-41717  Medium
```