### PR TITLE
Upgrade dependencies

### DIFF
--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -4,7 +4,7 @@ const homepage = "https://github.com/badeball/cypress-configuration";
 
 export function fail(message: string) {
   throw new Error(
-    `${message} (this might be a bug, please report at ${homepage})`
+    `${message} (this might be a bug, please report at ${homepage})`,
   );
 }
 
@@ -18,7 +18,7 @@ export function assert(value: any, message?: string): asserts value {
 
 export function assertAndReturn<T>(
   value: T,
-  message?: string
+  message?: string,
 ): Exclude<T, false | null | undefined> {
   assert(value, message);
   return value as Exclude<T, false | null | undefined>;
@@ -26,7 +26,7 @@ export function assertAndReturn<T>(
 
 export function assertIsString(
   value: any,
-  message: string
+  message: string,
 ): asserts value is string {
   assert(isString(value), message);
 }

--- a/lib/cypress-configuration/cypress-post10-configuration-parser.test.ts
+++ b/lib/cypress-configuration/cypress-post10-configuration-parser.test.ts
@@ -73,9 +73,9 @@ function example<T extends keyof TestConfiguration>(options: {
               testingType,
               property,
               value,
-            })
+            }),
           ),
-          expected
+          expected,
         );
       });
     }

--- a/lib/cypress-configuration/cypress-post10-configuration-parser.ts
+++ b/lib/cypress-configuration/cypress-post10-configuration-parser.ts
@@ -52,13 +52,13 @@ function parseTestingTypeObject(object: ObjectExpression): TestConfiguration {
               throw new Error(
                 `Expected a string literal for ${propertyName}.[], but got ${
                   element?.type ?? "null"
-                }`
+                }`,
               );
             }
           });
         } else {
           throw new Error(
-            `Expected a string literal for ${propertyName}, but got ${property.value.type}`
+            `Expected a string literal for ${propertyName}, but got ${property.value.type}`,
           );
         }
       } else if (property.key.name === "reporter") {
@@ -68,7 +68,7 @@ function parseTestingTypeObject(object: ObjectExpression): TestConfiguration {
           test[propertyName] = property.value.value;
         } else {
           throw new Error(
-            `Expected a string literal for ${propertyName}, but got ${property.value.type}`
+            `Expected a string literal for ${propertyName}, but got ${property.value.type}`,
           );
         }
       } else if (property.key.name === "env") {
@@ -77,7 +77,7 @@ function parseTestingTypeObject(object: ObjectExpression): TestConfiguration {
         } else {
           throw new Error(
             "Expected a ObjectExpression for e2e, but got " +
-              property.value.type
+              property.value.type,
           );
         }
       }

--- a/lib/cypress-configuration/cypress-post10-configuration.test.ts
+++ b/lib/cypress-configuration/cypress-post10-configuration.test.ts
@@ -31,10 +31,10 @@ function example(
     parseDangerously?: boolean;
   },
   attribute: keyof ICypressPost10Configuration,
-  expected: any
+  expected: any,
 ) {
   it(`should return ${attribute} = "${util.inspect(
-    expected
+    expected,
   )}" for ${util.inspect(options)}}`, () => {
     const {
       cypressConfig = "module.exports = {};",
@@ -54,13 +54,13 @@ function example(
 
     fs.writeFileSync(
       path.join(fullCypressProjectPath, cypressConfigPath),
-      cypressConfig
+      cypressConfig,
     );
 
     if (cypressEnvConfig) {
       fs.writeFileSync(
         path.join(fullCypressProjectPath, "cypress.env.json"),
-        JSON.stringify(cypressEnvConfig, null, 2)
+        JSON.stringify(cypressEnvConfig, null, 2),
       );
     }
 
@@ -105,7 +105,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -121,7 +121,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -137,7 +137,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -153,7 +153,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -217,7 +217,7 @@ describe("resolvePost10Configuration()", () => {
             env,
           },
           "specPattern",
-          expected
+          expected,
         );
       }
 
@@ -229,7 +229,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfig: `module.exports = { ${testingType}: { specPattern: 'foo/bar' } };`,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.cjs
@@ -241,7 +241,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfigPath: "cypress.config.cjs",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.mjs
@@ -253,7 +253,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfigPath: "cypress.config.mjs",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.ts
@@ -265,7 +265,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfigPath: "cypress.config.ts",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       });
 
@@ -278,7 +278,7 @@ describe("resolvePost10Configuration()", () => {
             parseDangerously: true,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.cjs
@@ -291,7 +291,7 @@ describe("resolvePost10Configuration()", () => {
             parseDangerously: true,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.mjs
@@ -304,7 +304,7 @@ describe("resolvePost10Configuration()", () => {
             parseDangerously: true,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
 
         // Override with cypress.config.ts
@@ -317,7 +317,7 @@ describe("resolvePost10Configuration()", () => {
             parseDangerously: true,
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       });
 
@@ -335,7 +335,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfigPath: "foo.js",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -353,7 +353,7 @@ describe("resolvePost10Configuration()", () => {
             cypressProjectPath: "foo",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -372,7 +372,7 @@ describe("resolvePost10Configuration()", () => {
             cypressProjectPath: "foo",
           },
           "specPattern",
-          "foo/bar"
+          "foo/bar",
         );
       }
 
@@ -384,7 +384,7 @@ describe("resolvePost10Configuration()", () => {
           testingType,
         },
         "env",
-        {}
+        {},
       );
 
       // Simple CLI override
@@ -399,7 +399,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
 
@@ -415,7 +415,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "env",
-          { FOO: "foo", BAR: "bar" }
+          { FOO: "foo", BAR: "bar" },
         );
       }
 
@@ -431,7 +431,7 @@ describe("resolvePost10Configuration()", () => {
             argv,
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
 
@@ -473,7 +473,7 @@ describe("resolvePost10Configuration()", () => {
               env,
             },
             "env",
-            expected
+            expected,
           );
         }
       }
@@ -485,7 +485,7 @@ describe("resolvePost10Configuration()", () => {
           cypressConfig: `module.exports = { ${testingType}: { env: { FOO: 'foo' } } };`,
         },
         "env",
-        { FOO: "foo" }
+        { FOO: "foo" },
       );
 
       // Override with cypress.config.js in custom location
@@ -502,7 +502,7 @@ describe("resolvePost10Configuration()", () => {
             cypressConfigPath: "foo.js",
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
 
@@ -513,7 +513,7 @@ describe("resolvePost10Configuration()", () => {
           cypressEnvConfig: { FOO: "foo" },
         },
         "env",
-        { FOO: "foo" }
+        { FOO: "foo" },
       );
 
       // Override with cypress.config.js & custom project path.
@@ -530,7 +530,7 @@ describe("resolvePost10Configuration()", () => {
             cypressProjectPath: "foo",
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
 
@@ -549,7 +549,7 @@ describe("resolvePost10Configuration()", () => {
             cypressProjectPath: "foo",
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
 
@@ -567,7 +567,7 @@ describe("resolvePost10Configuration()", () => {
             cypressProjectPath: "foo",
           },
           "env",
-          { FOO: "foo" }
+          { FOO: "foo" },
         );
       }
     });

--- a/lib/cypress-configuration/cypress-post10-configuration.ts
+++ b/lib/cypress-configuration/cypress-post10-configuration.ts
@@ -68,13 +68,13 @@ function isPlainObject(value: any): value is object {
 
 function validateConfigurationEntry(
   key: string,
-  value: unknown
+  value: unknown,
 ): Partial<ICypressPost10Configuration> {
   switch (key) {
     case "projectRoot":
       if (!isString(value)) {
         throw new Error(
-          `Expected a string (projectRoot), but got ${util.inspect(value)}`
+          `Expected a string (projectRoot), but got ${util.inspect(value)}`,
         );
       }
       return { [key]: value };
@@ -82,8 +82,8 @@ function validateConfigurationEntry(
       if (!isStringOrStringArray(value)) {
         throw new Error(
           `Expected a string or array of strings (specPattern), but got ${util.inspect(
-            value
-          )}`
+            value,
+          )}`,
         );
       }
       return { [key]: value };
@@ -91,15 +91,15 @@ function validateConfigurationEntry(
       if (!isStringOrStringArray(value)) {
         throw new Error(
           `Expected a string or array of strings (excludeSpecPattern), but got ${util.inspect(
-            value
-          )}`
+            value,
+          )}`,
         );
       }
       return { [key]: value };
     case "env":
       if (!isPlainObject(value)) {
         throw new Error(
-          `Expected a plain object (env), but got ${util.inspect(value)}`
+          `Expected a plain object (env), but got ${util.inspect(value)}`,
         );
       }
       return { [key]: value };
@@ -116,7 +116,7 @@ export function resolvePost10Configuration(options: {
   testingType: TestingType;
 }): ICypressPost10Configuration {
   debug(
-    `attempting to resolve Cypress configuration using ${util.inspect(options)}`
+    `attempting to resolve Cypress configuration using ${util.inspect(options)}`,
   );
 
   const { argv, env, testingType } = options;
@@ -128,8 +128,8 @@ export function resolvePost10Configuration(options: {
     ...Array.from(
       combine(
         traverseArgvMatching(argv, "--config", true),
-        traverseArgvMatching(argv, "-c", false)
-      )
+        traverseArgvMatching(argv, "-c", false),
+      ),
     )
       .reverse()
       .flatMap((argument) => {
@@ -142,7 +142,7 @@ export function resolvePost10Configuration(options: {
         }
 
         return entries;
-      })
+      }),
   );
 
   const envPrefixExpr = /^cypress_(.+)/i;
@@ -159,7 +159,7 @@ export function resolvePost10Configuration(options: {
 
         assert(
           match,
-          "cypress-cucumber-preprocessor: expected match after test, this is likely a bug."
+          "cypress-cucumber-preprocessor: expected match after test, this is likely a bug.",
         );
 
         return [assertAndReturn(match[1]), entry[1]];
@@ -167,14 +167,14 @@ export function resolvePost10Configuration(options: {
       .map((entry) => {
         return validateConfigurationEntry(
           entry[0].includes("_") ? toCamelCase(entry[0]) : entry[0],
-          entry[1]
+          entry[1],
         );
-      })
+      }),
   );
 
   const cypressConfigPath = ensureIsAbsolute(
     projectPath,
-    resolveConfigurationFile(options)
+    resolveConfigurationFile(options),
   );
 
   const configOrigin: Partial<ICypressPost10Configuration> = Object.assign(
@@ -182,9 +182,9 @@ export function resolvePost10Configuration(options: {
     ...Object.entries(
       parseConfigurationFile(
         cypressConfigPath,
-        options.parseDangerously ?? false
-      )[testingType] ?? {}
-    ).map((entry) => validateConfigurationEntry(...entry))
+        options.parseDangerously ?? false,
+      )[testingType] ?? {},
+    ).map((entry) => validateConfigurationEntry(...entry)),
   );
 
   const defaults =
@@ -209,7 +209,7 @@ export function resolvePost10Configuration(options: {
     },
     configOrigin,
     envOrigin,
-    cliOrigin
+    cliOrigin,
   );
 
   debug(`resolved configuration of ${util.inspect(configuration)}`);
@@ -232,7 +232,7 @@ function resolvePre10Environment(options: {
   configOrigin: Record<string, any>;
 }): Record<string, any> {
   debug(
-    `attempting to resolve Cypress environment using ${util.inspect(options)}`
+    `attempting to resolve Cypress environment using ${util.inspect(options)}`,
   );
 
   const { argv, env, projectPath, configOrigin } = options;
@@ -240,13 +240,13 @@ function resolvePre10Environment(options: {
   const envEntries = Array.from(
     combine(
       traverseArgvMatching(argv, "--env", true),
-      traverseArgvMatching(argv, "-e", false)
-    )
+      traverseArgvMatching(argv, "-e", false),
+    ),
   );
 
   if (envEntries.length > 1) {
     console.warn(
-      "You have specified -e / --env multiple times. This is likely a mistake, as only the last one will take affect. Multiple values should instead be comma-separated."
+      "You have specified -e / --env multiple times. This is likely a mistake, as only the last one will take affect. Multiple values should instead be comma-separated.",
     );
   }
 
@@ -261,7 +261,7 @@ function resolvePre10Environment(options: {
       }
 
       return entries;
-    })
+    }),
   );
 
   const envPrefixExpr = /^cypress_(.+)/i;
@@ -278,7 +278,7 @@ function resolvePre10Environment(options: {
         assert(match, "expected match after test");
 
         return [assertAndReturn(match[1]), entry[1]];
-      })
+      }),
   );
 
   const cypressEnvironmentFilePath = path.join(projectPath, "cypress.env.json");
@@ -298,7 +298,7 @@ function resolvePre10Environment(options: {
     cypressEnvOrigin,
     configOrigin,
     envOrigin,
-    cliOrigin
+    cliOrigin,
   );
 
   debug(`resolved environment of ${util.inspect(environment)}`);
@@ -333,11 +333,11 @@ function findConfigurationInFS(options: {
 
   if (configFiles.length === 0) {
     throw new MissingConfigurationFileError(
-      "Unable to find a Cypress configuration file."
+      "Unable to find a Cypress configuration file.",
     );
   } else if (configFiles.length > 1) {
     throw new MultipleConfigurationFilesError(
-      "Found multiple Cypress configuration files."
+      "Found multiple Cypress configuration files.",
     );
   }
 
@@ -346,7 +346,7 @@ function findConfigurationInFS(options: {
 
 function parseConfigurationFile(
   configFile: string,
-  parseDangerously: boolean
+  parseDangerously: boolean,
 ): ConfigurationFile {
   if (parseDangerously) {
     return parseConfigurationFileDangerously(configFile);
@@ -356,11 +356,11 @@ function parseConfigurationFile(
 }
 
 function parseConfigurationFileDangerously(
-  configFile: string
+  configFile: string,
 ): ConfigurationFile {
   if (!fs.existsSync(configFile)) {
     throw new MissingConfigurationFileError(
-      "Missing Cypress configuration file."
+      "Missing Cypress configuration file.",
     );
   }
 
@@ -397,7 +397,7 @@ function parseConfigurationFileDangerously(
 }
 
 export function resolvePost10TestFiles(
-  configuration: ICypressPost10Configuration
+  configuration: ICypressPost10Configuration,
 ): string[] {
   let {
     projectRoot,
@@ -419,6 +419,6 @@ export function resolvePost10TestFiles(
   };
 
   return specPatterns.flatMap((specPattern) =>
-    glob.sync(specPattern, globOptions)
+    glob.sync(specPattern, globOptions),
   );
 }

--- a/lib/cypress-configuration/cypress-post10-configuration.ts
+++ b/lib/cypress-configuration/cypress-post10-configuration.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 import util from "util";
 
-import glob, { IOptions } from "glob";
+import glob from "glob";
 
 import hook from "node-hook";
 
@@ -411,7 +411,7 @@ export function resolvePost10TestFiles(
     .flat()
     .concat("**/node_modules/**");
 
-  const globOptions: IOptions = {
+  const globOptions = {
     absolute: true,
     nodir: true,
     cwd: projectRoot,

--- a/lib/cypress-configuration/helpers.ts
+++ b/lib/cypress-configuration/helpers.ts
@@ -5,7 +5,7 @@ import { ensureIsAbsolute } from "../path-helpers";
 export function findLastIndex<T>(
   collection: ArrayLike<T>,
   predicate: (value: T) => boolean,
-  beforeIndex = collection.length
+  beforeIndex = collection.length,
 ): number {
   for (let i = beforeIndex - 1; i >= 0; --i) {
     if (predicate(collection[i])) {
@@ -19,7 +19,7 @@ export function findLastIndex<T>(
 export function* traverseArgvMatching(
   argv: string[],
   name: string,
-  allowEqual: boolean
+  allowEqual: boolean,
 ) {
   let beforeIndex = argv.length,
     matchingIndex;
@@ -28,7 +28,7 @@ export function* traverseArgvMatching(
     (matchingIndex = findLastIndex(
       argv,
       (arg) => arg.startsWith(name),
-      beforeIndex
+      beforeIndex,
     )) !== -1
   ) {
     if (argv[matchingIndex] === name) {
@@ -54,7 +54,7 @@ export function* combine<T>(...generators: Generator<T, unknown, unknown>[]) {
 export function findArgumentValue(
   argv: string[],
   name: string,
-  allowEqual: boolean
+  allowEqual: boolean,
 ): string | undefined {
   for (const value of traverseArgvMatching(argv, name, allowEqual)) {
     return value;
@@ -73,7 +73,7 @@ export function toCamelCase(value: string) {
   return value
     .split("_")
     .map((word, index) =>
-      index === 0 ? word.toLocaleLowerCase() : capitalize(word)
+      index === 0 ? word.toLocaleLowerCase() : capitalize(word),
     )
     .join("");
 }

--- a/lib/cypress-configuration/index.ts
+++ b/lib/cypress-configuration/index.ts
@@ -63,28 +63,28 @@ export function determineCypressEra(options: {
         return CypressEra.POST_V10;
       } else {
         throw new UnrecognizedConfigurationFileError(
-          "Unrecognized file " + name
+          "Unrecognized file " + name,
         );
       }
     } else {
       throw new MissingConfigurationFileError(
-        "Missing Cypress configuration file."
+        "Missing Cypress configuration file.",
       );
     }
   } else {
     const files = fs.readdirSync(projectRoot);
 
     const configFiles = files.filter((file) =>
-      [PRE10_CONFIG_FILE_NAME, ...POST10_CONFIG_FILE_NAMES].includes(file)
+      [PRE10_CONFIG_FILE_NAME, ...POST10_CONFIG_FILE_NAMES].includes(file),
     );
 
     if (configFiles.length === 0) {
       throw new MissingConfigurationFileError(
-        "Unable to find a Cypress configuration file."
+        "Unable to find a Cypress configuration file.",
       );
     } else if (configFiles.length > 1) {
       throw new MultipleConfigurationFilesError(
-        "Found multiple Cypress configuration files."
+        "Found multiple Cypress configuration files.",
       );
     }
 
@@ -109,7 +109,7 @@ export function resolveConfiguration(options: {
 
   if (era === CypressEra.PRE_V10) {
     throw new UnsupportedCypressEra(
-      "Unable resolve configuration of Cypress versions below v10"
+      "Unable resolve configuration of Cypress versions below v10",
     );
   } else {
     return resolvePost10Configuration(options);
@@ -117,13 +117,13 @@ export function resolveConfiguration(options: {
 }
 
 export function resolveTestFiles(
-  configuration: ICypressConfiguration
+  configuration: ICypressConfiguration,
 ): string[] {
   if ("specPattern" in configuration) {
     return resolvePost10TestFiles(configuration);
   } else {
     throw new UnsupportedCypressEra(
-      "Unable resolve test files of Cypress versions below v10"
+      "Unable resolve test files of Cypress versions below v10",
     );
   }
 }

--- a/lib/type-guards.ts
+++ b/lib/type-guards.ts
@@ -15,7 +15,7 @@ export function isStringOrFalse(value: unknown): value is string | false {
 }
 
 export function isStringOrStringArray(
-  value: unknown
+  value: unknown,
 ): value is string | string[] {
   return (
     typeof value === "string" || (Array.isArray(value) && value.every(isString))

--- a/package.json
+++ b/package.json
@@ -29,22 +29,22 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test"
   },
   "dependencies": {
-    "@babel/parser": "^7.18.8",
-    "debug": "^4.3.2",
-    "esbuild": "^0.19.4",
-    "glob": "^7.1.6",
-    "minimatch": "^3.0.4",
+    "@babel/parser": "^7.25.6",
+    "debug": "^4.3.7",
+    "esbuild": "^0.23.1",
+    "glob": "^11.0.0",
+    "minimatch": "^10.0.1",
     "node-hook": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/types": "^7.18.8",
-    "@types/debug": "^4.1.7",
-    "@types/glob": "^7.1.4",
-    "@types/mocha": "^9.0.0",
-    "@types/node-hook": "^1.0.1",
-    "mocha": "^8.2.0",
-    "prettier": "^2.2.1",
-    "ts-node": "^10.3.0",
-    "typescript": "^4.0.3"
+    "@babel/types": "^7.25.6",
+    "@types/debug": "^4.1.12",
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "^10.0.8",
+    "@types/node-hook": "^1.0.3",
+    "mocha": "^10.7.3",
+    "prettier": "^3.3.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.2"
   }
 }


### PR DESCRIPTION
This PR updates all dependencies listed in the package.json to their latest versions. The primary objective is to resolve warnings generated during npm install, while also ensuring that all dependencies remain up-to-date for better security, performance and compatibility.

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.1.6: Glob versions prior to v9 are no longer supported
```